### PR TITLE
Thread safety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 os: osx
-osx_image: xcode8
+osx_image: xcode9
 sudo: false
 language: objective-c
 
 env:
-  - SDK="iphoneos10.0"
+  - SDK="iphoneos11.0"
 
 script:
   - xcodebuild clean build -sdk $SDK -configuration Debug CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sniffer
 
 [![Build Status](https://travis-ci.org/Kofktu/Sniffer.svg?branch=master)](https://travis-ci.org/Kofktu/Sniffer)
-![Swift](https://img.shields.io/badge/Swift-3.0-orange.svg)
+![Swift](https://img.shields.io/badge/Swift-4.0-orange.svg)
 [![CocoaPods](http://img.shields.io/cocoapods/v/Sniffer.svg?style=flat)](http://cocoapods.org/?q=name%3ASniffer%20author%3AKofktu)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 

--- a/Sniffer/Classes/Sniffer.swift
+++ b/Sniffer/Classes/Sniffer.swift
@@ -9,21 +9,21 @@
 import Foundation
 
 public class Sniffer: URLProtocol {
-    
+
     private enum Keys {
         static let request = "Sniffer.request"
         static let duration = "Sniffer.duration"
     }
-    
+
     static public var onLogger: ((String) -> Void)? // If the handler is registered, the log inside the Sniffer will not be output.
-    
+
     private lazy var session: URLSession = URLSession(configuration: URLSessionConfiguration.default, delegate: self, delegateQueue: nil)
     private var urlTask: URLSessionDataTask?
     private var urlRequest: NSMutableURLRequest?
     private var urlResponse: HTTPURLResponse?
     private var data: Data?
     private let serialQueue = DispatchQueue(label: "com.kofktu.sniffer.serialQueue")
-    
+
     private static var bodyDeserializers: [String: BodyDeserializer] = [
         "application/x-www-form-urlencoded": PlainTextBodyDeserializer(),
         "*/json": JSONBodyDeserializer(),
@@ -31,51 +31,51 @@ public class Sniffer: URLProtocol {
         "text/plain": PlainTextBodyDeserializer(),
         "*/html": HTMLBodyDeserializer()
     ]
-    
+
     public class func register() {
         URLProtocol.registerClass(self)
     }
-    
+
     public class func unregister() {
         URLProtocol.unregisterClass(self)
     }
-    
+
     public class func enable(in configuration: URLSessionConfiguration) {
         configuration.protocolClasses?.insert(Sniffer.self, at: 0)
     }
-    
+
     public class func register(deserializer: BodyDeserializer, `for` contentTypes: [String]) {
         for contentType in contentTypes {
             guard contentType.components(separatedBy: "/").count == 2 else { continue }
             bodyDeserializers[contentType] = deserializer
         }
     }
-    
+
     // MARK: - URLProtocol
     open override class func canInit(with request: URLRequest) -> Bool {
         guard let url = request.url, let scheme = url.scheme else { return false }
         return ["http", "https"].contains(scheme) && self.property(forKey: Keys.request, in: request)  == nil
     }
-    
+
     open override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         return request
     }
-    
+
     open override func startLoading() {
         if let _ = urlTask { return }
         guard let urlRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest , self.urlRequest == nil else { return }
-        
+
         self.urlRequest = urlRequest
-        
+
         Sniffer.setProperty(true, forKey: Keys.request, in: urlRequest)
         Sniffer.setProperty(Date(), forKey: Keys.duration, in: urlRequest)
-        
+
         log(request: urlRequest as URLRequest)
-        
+
         urlTask = session.dataTask(with: request)
         urlTask?.resume()
     }
-    
+
     open override func stopLoading() {
         serialQueue.sync { [weak self] in
             self?.urlTask?.cancel()
@@ -83,8 +83,9 @@ public class Sniffer: URLProtocol {
             self?.session.invalidateAndCancel()
         }
     }
-    
+
     // MARK: - Private
+
     private func log(_ string: String) {
         if let _ = Sniffer.onLogger {
             Sniffer.onLogger?(string)
@@ -92,7 +93,7 @@ public class Sniffer: URLProtocol {
             print(string)
         }
     }
-    
+
     fileprivate func clear() {
         defer {
             urlTask = nil
@@ -100,27 +101,34 @@ public class Sniffer: URLProtocol {
             urlResponse = nil
             data = nil
         }
-        
+
         guard let urlRequest = urlRequest else { return }
-        
+
         Sniffer.removeProperty(forKey: Keys.request, in: urlRequest)
         Sniffer.removeProperty(forKey: Keys.duration, in: urlRequest)
     }
-    
-    fileprivate func logDivider() {
-        log("============================================================")
+
+    fileprivate var logDivider: String {
+        return "==========================================================="
     }
-    
-    fileprivate func log(headers: [String: String]?) {
-        guard let headers = headers, !headers.isEmpty else { return }
-        
-        log("Headers: [")
+
+    fileprivate var errorLogDivider: String {
+        return "===========================ERROR==========================="
+    }
+
+    fileprivate func log(headers: [String: String]?) -> String {
+        guard let headers = headers, !headers.isEmpty else { return "" }
+
+        var headerLog = ""
+        headerLog += "Headers: [" + "\n"
         for (key, value) in headers {
-            log("  \(key) : \(value)")
+            headerLog += "  \(key) : \(value)" + "\n"
         }
-        log("]")
+        headerLog += "]" + "\n"
+
+        return headerLog
     }
-    
+
     private func body(from request: URLRequest) -> Data? {
         return request.httpBody ?? request.httpBodyStream.flatMap { stream in
             let data = NSMutableData()
@@ -134,13 +142,13 @@ public class Sniffer: URLProtocol {
             return data as Data
         }
     }
-    
+
     private func find(deserialize contentType: String) -> BodyDeserializer? {
         for (pattern, deserializer) in Sniffer.bodyDeserializers {
             do {
                 let regex = try NSRegularExpression(pattern: pattern.replacingOccurrences(of: "*", with: "[a-z]+"))
                 let results = regex.matches(in: contentType, range: NSRange(location: 0, length: contentType.count))
-                
+
                 if !results.isEmpty {
                     return deserializer
                 }
@@ -148,127 +156,143 @@ public class Sniffer: URLProtocol {
                 continue
             }
         }
-        
+
         return nil
     }
-    
+
     private func deserialize(body: Data, `for` contentType: String) -> String? {
         return find(deserialize: contentType)?.deserialize(body: body)
     }
-    
-    fileprivate func log(body request: URLRequest) {
-        guard let body = body(from: request) else { return }
-        
-        if let deserialize = deserialize(body: body, for: request.value(forHTTPHeaderField: "Content-Type") ?? "application/octet-stream") {
-            log("Body: [")
-            log(deserialize)
-            log("]")
+
+    fileprivate func log(body request: URLRequest) -> String {
+        guard let body = body(from: request) else { return "" }
+
+        var bodyLog = ""
+
+        if let deserialized = deserialize(body: body, for: request.value(forHTTPHeaderField: "Content-Type") ?? "application/octet-stream") {
+            bodyLog += "Body: [" + "\n"
+            bodyLog += deserialized + "\n"
+            bodyLog += "]" + "\n"
         }
+
+        return bodyLog
     }
-    
+
     fileprivate func log(request: URLRequest) {
-        logDivider()
-        
+        var logString = logDivider + "\n"
+
         if let method = request.httpMethod, let url = request.url?.absoluteString {
-            log("Request [\(method)] : \(url)")
+            logString += "Request [\(method)] : \(url)" + "\n"
         }
-        
-        log(headers: request.allHTTPHeaderFields)
-        log(body: request)
-        
-        logDivider()
+
+        logString += log(headers: request.allHTTPHeaderFields)
+        logString += log(body: request)
+
+        logString += logDivider
+
+        log(logString)
     }
-    
+
     fileprivate func log(response: URLResponse, data: Data?) {
-        logDivider()
-        
+        var logString = logDivider + "\n"
+
         var contentType = "application/octet-stream"
-        
+
         if let url = response.url?.absoluteString {
-            log("Response : \(url)")
+            logString += "Response : \(url)" + "\n"
         }
-        
+
         if let httpResponse = response as? HTTPURLResponse {
             let localisedStatus = HTTPURLResponse.localizedString(forStatusCode: httpResponse.statusCode).capitalized
-            log("Status: \(httpResponse.statusCode) - \(localisedStatus)")
-            log(headers: httpResponse.allHeaderFields as? [String: String])
-            
+            logString += "Status: \(httpResponse.statusCode) - \(localisedStatus)" + "\n"
+            logString += log(headers: httpResponse.allHeaderFields as? [String: String]) + "\n"
+
             if let type = httpResponse.allHeaderFields["Content-Type"] as? String {
                 contentType = type
             }
         }
-        
+
         if let urlRequest = urlRequest as URLRequest?, let startDate = Sniffer.property(forKey: Keys.duration, in: urlRequest) as? Date {
             let difference = fabs(startDate.timeIntervalSinceNow)
-            log("Duration: \(difference)s")
+            logString += "Duration: \(difference)s"
         }
-        
+
         defer {
-            logDivider()
+            logString += logDivider + "\n"
         }
-        
-        guard let body = data else { return }
-        
+
+        guard let body = data else {
+            log(logString)
+            return
+        }
+
         if let deserialize = deserialize(body: body, for: contentType) ?? PlainTextBodyDeserializer().deserialize(body: body) {
-            log("Body: [")
-            log(deserialize)
-            log("]")
+            logString += "Body: [" + "\n"
+            logString += deserialize + "\n"
+            logString += "]" + "\n"
         }
+
+        logString += logDivider
+
+        log(logString)
     }
-    
-    fileprivate func log(error: Error?) {
-        guard let error = error else { return }
-        
-        log("=======================ERROR================================")
+
+    fileprivate func log(error: Error?) -> String {
+        guard let error = error else { return "" }
+
+        var logString = errorLogDivider + "\n"
+
         let nsError = error as NSError
 
-        log("Code : \(nsError.code)")
-        log("Description : \(nsError.localizedDescription)")
-        
+        logString += "Code : \(nsError.code)" + "\n"
+        logString += "Description : \(nsError.localizedDescription)" + "\n"
+
         if let reason = nsError.localizedFailureReason {
-            log("Reason : \(reason)")
+            logString += "Reason : \(reason)" + "\n"
         }
         if let suggestion = nsError.localizedRecoverySuggestion {
-            log("Suggestion : \(suggestion)")
+            logString += "Suggestion : \(suggestion)" + "\n"
         }
-        
-        logDivider()
+
+        logString += logDivider + "\n"
+
+        return logString
     }
 }
 
 extension Sniffer: URLSessionTaskDelegate, URLSessionDataDelegate {
-    
+
     // MARK: - NSURLSessionDataDelegate
     public func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
         client?.urlProtocol(self, wasRedirectedTo: request, redirectResponse: response)
     }
-    
+
     public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
         urlResponse = response as? HTTPURLResponse
         data = Data()
-        
+
         completionHandler(.allow)
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .allowed)
     }
-    
+
     public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         self.data?.append(data)
         client?.urlProtocol(self, didLoad: data)
     }
-    
+
     public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         if let error = error {
-            log(error: error)
+            log(log(error: error))
             client?.urlProtocol(self, didFailWithError: error)
         } else if let urlResponse = urlResponse {
             log(response: urlResponse, data: data)
             client?.urlProtocolDidFinishLoading(self)
         }
-        
+
         serialQueue.sync { [weak self] in
             self?.clear()
         }
         session.finishTasksAndInvalidate()
     }
-    
+
 }


### PR DESCRIPTION
Currently every single log line is printed individually. That's why the logger isn't thread safe. When initiating multiple asynchronous network requests the logs can get mixed up easily. This can be dangerous because the user might not be aware of that issue.

I recommend building the logs for every request, response and error respectively and then printing them atomically. This prevents the mixup.